### PR TITLE
Added two new functions to Adafruit_LEDBackpack

### DIFF
--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -213,6 +213,10 @@ void Adafruit_LEDBackpack::begin(uint8_t _addr = 0x70) {
   setBrightness(15); // max brightness
 }
 
+void Adafruit_LEDBackpack::setAddr(uint8_t _addr = 0x70) {
+  i2c_addr = _addr;
+}
+
 void Adafruit_LEDBackpack::writeDisplay(void) {
   Wire.beginTransmission(i2c_addr);
   Wire.write((uint8_t)0x00); // start at address $00
@@ -252,6 +256,14 @@ void Adafruit_AlphaNum4::writeDigitAscii(uint8_t n, uint8_t a,  boolean d) {
   */
 
   if (d) displaybuffer[n] |= (1<<14);
+}
+
+uint16_t Adafruit_AlphaNum4::asciiToRaw(uint8_t a,  boolean d) {
+  uint16_t font = pgm_read_word(alphafonttable+a);
+
+  if (d) font |= (1<<14);
+
+  return font;
 }
 
 /******************************* 24 BARGRAPH OBJECT */

--- a/Adafruit_LEDBackpack.h
+++ b/Adafruit_LEDBackpack.h
@@ -59,6 +59,7 @@ class Adafruit_LEDBackpack {
  public:
   Adafruit_LEDBackpack(void);
   void begin(uint8_t _addr);
+  void setAddr(uint8_t _addr);
   void setBrightness(uint8_t b);
   void blinkRate(uint8_t b);
   void writeDisplay(void);
@@ -77,6 +78,7 @@ class Adafruit_AlphaNum4 : public Adafruit_LEDBackpack {
 
   void writeDigitRaw(uint8_t n, uint16_t bitmask);
   void writeDigitAscii(uint8_t n, uint8_t ascii, boolean dot = false);
+  uint16_t asciiToRaw(uint8_t ascii, boolean dot = false);
 
  private:
 


### PR DESCRIPTION
To handle multiple displays without calling begin() in between writes, I added a setAddr() function, which just sets the current i2c_addr without modifying the oscillator, blink, or brightness of the display.
Also, to be able to look at and possibly modify the segments before writing, I added the function asciiToRaw(), which allows me to pass in an ASCII character and get back the raw segments that would light up.  This is done instead of making the alphafonttable public.
