### PR TITLE
Adds a fix for ESP8266 based board when using the ESP8266 Arduino core.

### DIFF
--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -27,6 +27,12 @@
 #include "Adafruit_LEDBackpack.h"
 #include "Adafruit_GFX.h"
 
+#ifdef ESP8266
+ #include <algorithm>
+ using namespace std;
+#endif
+
+
 #ifndef _BV
   #define _BV(bit) (1<<(bit))
 #endif


### PR DESCRIPTION
I'm not sure if this is the best fix, but it does work (Y)
https://www.instagram.com/p/BASlCD3M9X3/

Just add 'Wire.begin(D1, D2);' to your Arduino code setup function before the 'matrix.begin();'.
