### PR TITLE
Add a 16x16 matrix using two HK16K33

### DIFF
--- a/examples/matrix16x16/Adafruit_16x16matrix.cpp
+++ b/examples/matrix16x16/Adafruit_16x16matrix.cpp
@@ -1,0 +1,77 @@
+
+#include "Adafruit_16x16matrix.h"
+
+
+
+#ifndef _BV
+  #define _BV(bit) (1<<(bit))
+#endif
+
+#ifndef _swap_int16_t
+#define _swap_int16_t(a, b) { int16_t t = a; a = b; b = t; }
+#endif
+
+Adafruit_16x16matrix::Adafruit_16x16matrix(void) : Adafruit_GFX(16, 16) {
+}
+
+void Adafruit_16x16matrix::drawPixel(int16_t x, int16_t y, uint16_t color) {
+
+
+   
+ // check rotation, move pixel around if necessary
+  switch (getRotation()) {
+  case 2:
+    _swap_int16_t(x, y);
+    x = 16 - x - 1;
+    break;
+  case 3:
+    x = 16 - x - 1;
+    y = 16 - y - 1;
+    break;
+  case 0:
+    _swap_int16_t(x, y);
+    y = 16 - y - 1;
+    break;
+  }
+
+  Adafruit_LEDBackpack &ctrl = y>7 ? b:a;
+  if(y>=8) { 
+    y-=8;
+  }
+  /*
+  Serial.print("("); Serial.print(x);
+  Serial.print(","); Serial.print(y);
+  Serial.println(")");
+  */
+
+  if ((y < 0) || (y >= 8)) return;
+  if ((x < 0) || (x >= 16)) return;
+
+  if (color) {
+    ctrl.displaybuffer[y] |= 1 << x;
+  } else {
+    ctrl.displaybuffer[y] &= ~(1 << x);
+  }
+}
+
+
+  void  Adafruit_16x16matrix::begin(uint8_t addr1, uint8_t addr2) {
+    a.begin(addr1);
+    b.begin(addr2);
+  }
+  void  Adafruit_16x16matrix::setBrightness(uint8_t br) {
+    a.setBrightness(br);
+    b.setBrightness(br);
+  }
+  void  Adafruit_16x16matrix::blinkRate(uint8_t br) {
+    a.blinkRate(br);
+    b.blinkRate(br);
+  }
+  void  Adafruit_16x16matrix::writeDisplay(void) {
+    a.writeDisplay();
+    b.writeDisplay();
+  }
+  void  Adafruit_16x16matrix::clear(void) {
+    a.clear();
+    b.clear();
+  }

--- a/examples/matrix16x16/Adafruit_16x16matrix.h
+++ b/examples/matrix16x16/Adafruit_16x16matrix.h
@@ -1,0 +1,22 @@
+
+
+
+#include <Adafruit_GFX.h>
+#include "Adafruit_LEDBackpack.h"
+
+
+class Adafruit_16x16matrix : public Adafruit_GFX {
+ public:
+  Adafruit_16x16matrix(void);
+
+  void begin(uint8_t addr1, uint8_t addr2);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  
+  void setBrightness(uint8_t b);
+  void blinkRate(uint8_t b);
+  void writeDisplay(void);
+  void clear(void);
+
+private:
+  Adafruit_LEDBackpack a,b;
+};

--- a/examples/matrix16x16/matrix16x16.ino
+++ b/examples/matrix16x16/matrix16x16.ino
@@ -1,0 +1,72 @@
+/*************************************************** 
+  This is a library for our I2C LED Backpacks
+
+  Designed specifically to work with the Adafruit 16x8 LED Matrix backpacks 
+  ----> http://www.adafruit.com/products/2035
+  ----> http://www.adafruit.com/products/2036
+  ----> http://www.adafruit.com/products/2037
+  ----> http://www.adafruit.com/products/2038
+  ----> http://www.adafruit.com/products/2039
+  ----> http://www.adafruit.com/products/2040
+  ----> http://www.adafruit.com/products/2041
+  ----> http://www.adafruit.com/products/2042
+  ----> http://www.adafruit.com/products/2043
+  ----> http://www.adafruit.com/products/2044
+  ----> http://www.adafruit.com/products/2052
+
+  These displays use I2C to communicate, 2 pins are required to 
+  interface. There are multiple selectable I2C addresses. For backpacks
+  with 2 Address Select pins: 0x70, 0x71, 0x72 or 0x73. For backpacks
+  with 3 Address Select pins: 0x70 thru 0x77
+
+  Adafruit invests time and resources providing this open source code, 
+  please support Adafruit and open-source hardware by purchasing 
+  products from Adafruit!
+
+  Written by Limor Fried/Ladyada for Adafruit Industries.  
+  BSD license, all text above must be included in any redistribution
+ ****************************************************/
+
+#include <Wire.h>
+
+#include "Adafruit_16x16matrix.h"
+Adafruit_16x16matrix matrix = Adafruit_16x16matrix();
+
+void setup() {
+  Serial.begin(9600);
+  Serial.println("16x16 LED Matrix Test");
+  
+  matrix.begin(0x70, 0x71);  // pass in the address
+  matrix.setBrightness(15);
+}
+
+
+void loop() {
+
+   matrix.clear();
+  matrix.fillRect(0,0, 16,16, LED_ON);
+  
+  matrix.writeDisplay();  // write the changes we just made to the display
+  
+  delay(500);
+
+matrix.clear();
+  matrix.drawLine(0,0, 15,15, LED_ON);
+  
+  matrix.writeDisplay();  // write the changes we just made to the display
+  
+
+  delay(500);
+  
+
+  matrix.setTextSize(2);
+  matrix.setTextWrap(false);  // we dont want text to wrap so it scrolls nicely
+  matrix.setTextColor(LED_ON);
+  for (int8_t x=0; x>=-64; x--) {
+    matrix.clear();
+    matrix.setCursor(x,0);
+    matrix.print("Hello");
+    matrix.writeDisplay();
+    delay(100);
+  }
+}


### PR DESCRIPTION
This adds an Arduino Example implementing a class that utilizes two HT16K33 to access a 16x16 matrix (split into two 16x8 sections) as a single Adafruit_GFX target.

Let me know if you want to keep the code in your repository. I'll be happy to improve the code quality and documentation.