### PR TITLE
Default I2C address when calling begin didn't work

### DIFF
--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -202,7 +202,7 @@ void Adafruit_LEDBackpack::blinkRate(uint8_t b) {
 
 Adafruit_LEDBackpack::Adafruit_LEDBackpack(void) {}
 
-void Adafruit_LEDBackpack::begin(uint8_t _addr = 0x70) {
+void Adafruit_LEDBackpack::begin(uint8_t _addr) {
   i2c_addr = _addr;
 
   Wire.begin();

--- a/Adafruit_LEDBackpack.h
+++ b/Adafruit_LEDBackpack.h
@@ -65,7 +65,7 @@ public:
             brightness).
     @param  _addr  I2C address.
   */
-  void begin(uint8_t _addr);
+  void begin(uint8_t _addr = 0x70);
 
   /*!
     @brief  Set display brightness.


### PR DESCRIPTION
Calling begin with no argument didn't work because the default argument value was specified in the definition instead of in the declaration.