### PR TITLE
Update clock_sevenseg_ds1307 example

### DIFF
--- a/examples/clock_sevenseg_ds1307/clock_sevenseg_ds1307.ino
+++ b/examples/clock_sevenseg_ds1307/clock_sevenseg_ds1307.ino
@@ -11,8 +11,8 @@
 // ----> http://www.adafruit.com/products/878
 // ----> https://www.adafruit.com/products/264
 //
-// Adafruit invests time and resources providing this open source code, 
-// please support Adafruit and open-source hardware by purchasing 
+// Adafruit invests time and resources providing this open source code,
+// please support Adafruit and open-source hardware by purchasing
 // products from Adafruit!
 //
 // Written by Tony DiCola for Adafruit Industries.
@@ -73,7 +73,7 @@ void setup() {
     // This line sets the DS1307 time to the exact date and time the
     // sketch was compiled:
     rtc.adjust(DateTime(F(__DATE__), F(__TIME__)));
-    // Alternatively you can set the RTC with an explicit date & time, 
+    // Alternatively you can set the RTC with an explicit date & time,
     // for example to set January 21, 2014 at 3am you would uncomment:
     //rtc.adjust(DateTime(2014, 1, 21, 3, 0, 0));
   }
@@ -81,7 +81,7 @@ void setup() {
 
 void loop() {
   // Loop function runs over and over again to implement the clock logic.
-  
+
   // Check if it's the top of the hour and get a new time reading
   // from the DS1307.  This helps keep the clock accurate by fixing
   // any drift.
@@ -135,7 +135,7 @@ void loop() {
     clockDisplay.writeDigitNum(1, 0);
     // Also pad when the 10's minute is 0 and should be padded.
     if (minutes < 10) {
-      clockDisplay.writeDigitNum(2, 0);
+      clockDisplay.writeDigitNum(3, 0);
     }
   }
 


### PR DESCRIPTION
For #36. It looks like #33 was an attempt to fix this, but incorrect.

Recreated issue by setting `TIME_24_HOUR` true and forcing `hours=0` and `minutes=5`.

**BEFORE**
![before](https://user-images.githubusercontent.com/8755041/135354254-83661a87-e77c-431b-8e5f-2b56062ce310.jpg)

**AFTER**
![after](https://user-images.githubusercontent.com/8755041/135354272-0f370fbf-6330-4b20-bfac-cfcb3b084fec.jpg)


