### PR TITLE
Fix narrowing conversion warnings

### DIFF
--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -182,13 +182,14 @@ static const uint16_t alphafonttable[] PROGMEM = {
 
 };
 void Adafruit_LEDBackpack::setBrightness(uint8_t b) {
-  uint8_t buffer = HT16K33_CMD_BRIGHTNESS | (b > 15 ? 15 : b);
+  if (b > 15) b = 15;  // limit to max brightness
+  uint8_t buffer = HT16K33_CMD_BRIGHTNESS | b;
   i2c_dev->write(&buffer, 1);
 }
 
 void Adafruit_LEDBackpack::blinkRate(uint8_t b) {
-  uint8_t buffer = HT16K33_BLINK_CMD | HT16K33_BLINK_DISPLAYON |
-                       ((b > 3 ? 0 : b) << 1);
+  if (b > 3) b = 0;  // turn off if not sure
+  uint8_t buffer = HT16K33_BLINK_CMD | HT16K33_BLINK_DISPLAYON | (b << 1);
   i2c_dev->write(&buffer, 1);
 }
 

--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -182,13 +182,15 @@ static const uint16_t alphafonttable[] PROGMEM = {
 
 };
 void Adafruit_LEDBackpack::setBrightness(uint8_t b) {
-  if (b > 15) b = 15;  // limit to max brightness
+  if (b > 15)
+    b = 15; // limit to max brightness
   uint8_t buffer = HT16K33_CMD_BRIGHTNESS | b;
   i2c_dev->write(&buffer, 1);
 }
 
 void Adafruit_LEDBackpack::blinkRate(uint8_t b) {
-  if (b > 3) b = 0;  // turn off if not sure
+  if (b > 3)
+    b = 0; // turn off if not sure
   uint8_t buffer = HT16K33_BLINK_CMD | HT16K33_BLINK_DISPLAYON | (b << 1);
   i2c_dev->write(&buffer, 1);
 }

--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -182,14 +182,14 @@ static const uint16_t alphafonttable[] PROGMEM = {
 
 };
 void Adafruit_LEDBackpack::setBrightness(uint8_t b) {
-  uint8_t buffer[1] = {HT16K33_CMD_BRIGHTNESS | (b > 15 ? 15 : b)};
-  i2c_dev->write(buffer, 1);
+  uint8_t buffer = HT16K33_CMD_BRIGHTNESS | (b > 15 ? 15 : b);
+  i2c_dev->write(&buffer, 1);
 }
 
 void Adafruit_LEDBackpack::blinkRate(uint8_t b) {
-  uint8_t buffer[1] = {HT16K33_BLINK_CMD | HT16K33_BLINK_DISPLAYON |
-                       ((b > 3 ? 0 : b) << 1)};
-  i2c_dev->write(buffer, 1);
+  uint8_t buffer = HT16K33_BLINK_CMD | HT16K33_BLINK_DISPLAYON |
+                       ((b > 3 ? 0 : b) << 1);
+  i2c_dev->write(&buffer, 1);
 }
 
 Adafruit_LEDBackpack::Adafruit_LEDBackpack(void) {}


### PR DESCRIPTION
A recent change to the `setBrightness` and `blinkRate` functions switches from using a single variable to an brace-enclosed initializer list to create the buffer for the I2C command. This change generates 'narrowing conversion' compilation warnings:

```
Adafruit_LEDBackpack.cpp: In member function void Adafruit_LEDBackpack::setBrightness(uint8_t)
Adafruit_LEDBackpack.cpp: 185:47: warning: narrowing conversion of '(224 | ((((int)b) > 15) ? 15 : ((int)b)))' from 'int' to 'uint8_t {aka unsigned char}' inside { } [-Wnarrowing]
   b)}
Adafruit_LEDBackpack.cpp: In member function void Adafruit_LEDBackpack::blinkRate(uint8_t)
Adafruit_LEDBackpack.cpp: 190:68: warning: narrowing conversion of '((128 | 1) | (((((int)b) > 3) ? 0 : ((int)b)) << 1))' from 'int' to 'uint8_t {aka unsigned char}' inside { } [-Wnarrowing]
   uint8_t buffer[1] = {HT16K33_BLINK_CMD | HT16K33_BLINK_DISPLAYON |
```

To fix I changed the functions to use a single variable instead of a 1-length array. For good measure I also moved the ternary limit checks out of the command assembly onto their own line for better readability.

There should be no functional changes with this fix.