### PR TITLE
Added method to put the backpack in standby mode

### DIFF
--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -322,6 +322,16 @@ void Adafruit_LEDBackpack::clear(void) {
   }
 }
 
+void Adafruit_LEDBackpack::end() {
+  if (i2c_dev) {
+    // turn off oscillator
+    uint8_t buffer[1] = {0x20};
+    i2c_dev->write(buffer, 1);
+    // terminate I2C communication
+    i2c_dev->end();
+  }
+}
+
 /******************************* QUAD ALPHANUM OBJECT */
 
 Adafruit_AlphaNum4::Adafruit_AlphaNum4(void) {}

--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -327,8 +327,6 @@ void Adafruit_LEDBackpack::end() {
     // turn off oscillator
     uint8_t buffer[1] = {0x20};
     i2c_dev->write(buffer, 1);
-    // terminate I2C communication
-    i2c_dev->end();
   }
 }
 

--- a/Adafruit_LEDBackpack.h
+++ b/Adafruit_LEDBackpack.h
@@ -97,6 +97,11 @@ public:
   */
   void clear(void);
 
+  /*!
+    @brief Put HT16K33 in standby mode.
+  */
+  void end(void);
+
   uint16_t displaybuffer[8]; ///< Raw display data
 
 protected:


### PR DESCRIPTION
Proposal to add the "missing" .end() method to cleanly put the HT16K33 in standby mode.

I needed this for a very low power application where the display is off most of the time. Without setting the HT16K33 to standby mode, it consumes ~100uA (no LED on) extra. (reduction from 130uA to 30uA with a ATmega328P in power-down mode).

- This is a *new* method, so it should not be breaking anything if not called by the users.
- This is tested *only* on a 8x8 Bicolor Matrix, so I cannot say anything about other displays.
- A test program comparing the .end() versus just clearing the display is available at: https://github.com/flupes/chronodouche/blob/main/test/low_power_led_backpack/test_low_power_led_backpack.cpp
- Power measurements are shown at: https://www.youtube.com/watch?v=fxPFTtWQyig
