### PR TITLE
Fixed indexing for digits of the 7 segment display

### DIFF
--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -670,8 +670,15 @@ size_t Adafruit_7segment::write(const char *buffer, size_t size) {
 }
 
 void Adafruit_7segment::writeDigitRaw(uint8_t d, uint8_t bitmask) {
-  if (d > 4)
+  // to skip over index 2 in the displaybuffer, which is the colon
+  if(d > 1) {
+    d += 1;
+  }
+
+  if (d > 4) {
     return;
+  }
+
   displaybuffer[d] = bitmask;
 }
 

--- a/Adafruit_LEDBackpack.cpp
+++ b/Adafruit_LEDBackpack.cpp
@@ -671,7 +671,7 @@ size_t Adafruit_7segment::write(const char *buffer, size_t size) {
 
 void Adafruit_7segment::writeDigitRaw(uint8_t d, uint8_t bitmask) {
   // to skip over index 2 in the displaybuffer, which is the colon
-  if(d > 1) {
+  if (d > 1) {
     d += 1;
   }
 

--- a/examples/clock_sevenseg_ds1307/clock_sevenseg_ds1307.ino
+++ b/examples/clock_sevenseg_ds1307/clock_sevenseg_ds1307.ino
@@ -135,7 +135,7 @@ void loop() {
     clockDisplay.writeDigitNum(1, 0);
     // Also pad when the 10's minute is 0 and should be padded.
     if (minutes < 10) {
-      clockDisplay.writeDigitNum(3, 0);
+      clockDisplay.writeDigitNum(2, 0);
     }
   }
 


### PR DESCRIPTION
I changed the implementation of writeDigitRaw to account for the fact that the colon is index 2 in the display buffer. This fact led to the documentation in the header file being incorrect with regard to all of the writeDigit functions for the Adafruit_7Segment class.

This will break existing code that uses the backpack should the users of this library update the version they're using, but the usage and effect will match the documentation and what I think is the most reasonable assumption about the related functions' behaviors. 

This fixes #70, but breaks existing code using the library.