### PR TITLE
Add segment name definitions for alphanumeric displays

### DIFF
--- a/Adafruit_LEDBackpack.h
+++ b/Adafruit_LEDBackpack.h
@@ -50,6 +50,22 @@
 
 #define SEVENSEG_DIGITS 5 ///< # Digits in 7-seg displays, plus NUL end
 
+#define ALPHANUM_SEG_A  0b0000000000000001  ///< Alphanumeric segment A
+#define ALPHANUM_SEG_B  0b0000000000000010  ///< Alphanumeric segment B
+#define ALPHANUM_SEG_C  0b0000000000000100  ///< Alphanumeric segment C
+#define ALPHANUM_SEG_D  0b0000000000001000  ///< Alphanumeric segment D
+#define ALPHANUM_SEG_E  0b0000000000010000  ///< Alphanumeric segment E
+#define ALPHANUM_SEG_F  0b0000000000100000  ///< Alphanumeric segment F
+#define ALPHANUM_SEG_G1 0b0000000001000000  ///< Alphanumeric segment G1
+#define ALPHANUM_SEG_G2 0b0000000010000000  ///< Alphanumeric segment G2
+#define ALPHANUM_SEG_H  0b0000000100000000  ///< Alphanumeric segment H
+#define ALPHANUM_SEG_J  0b0000001000000000  ///< Alphanumeric segment J
+#define ALPHANUM_SEG_K  0b0000010000000000  ///< Alphanumeric segment K
+#define ALPHANUM_SEG_L  0b0000100000000000  ///< Alphanumeric segment L
+#define ALPHANUM_SEG_M  0b0001000000000000  ///< Alphanumeric segment M
+#define ALPHANUM_SEG_N  0b0010000000000000  ///< Alphanumeric segment N
+#define ALPHANUM_SEG_DP 0b0100000000000000  ///< Alphanumeric segment DP
+
 /*!
     @brief  Class encapsulating the raw HT16K33 controller device.
 */

--- a/Adafruit_LEDBackpack.h
+++ b/Adafruit_LEDBackpack.h
@@ -50,6 +50,25 @@
 
 #define SEVENSEG_DIGITS 5 ///< # Digits in 7-seg displays, plus NUL end
 
+/*
+Segment names for 14-segment alphanumeric displays.
+See https://learn.adafruit.com/14-segment-alpha-numeric-led-featherwing/usage
+
+    -------A-------
+    |\     |     /|
+    | \    J    / |
+    |   H  |  K   |
+    F    \ | /    B
+    |     \|/     |
+    |--G1--|--G2--|
+    |     /|\     |
+    E    / | \    C
+    |   L  |   N  |
+    | /    M    \ |
+    |/     |     \|
+    -------D-------  DP
+*/
+
 #define ALPHANUM_SEG_A 0b0000000000000001  ///< Alphanumeric segment A
 #define ALPHANUM_SEG_B 0b0000000000000010  ///< Alphanumeric segment B
 #define ALPHANUM_SEG_C 0b0000000000000100  ///< Alphanumeric segment C

--- a/Adafruit_LEDBackpack.h
+++ b/Adafruit_LEDBackpack.h
@@ -50,20 +50,20 @@
 
 #define SEVENSEG_DIGITS 5 ///< # Digits in 7-seg displays, plus NUL end
 
-#define ALPHANUM_SEG_A  0b0000000000000001  ///< Alphanumeric segment A
-#define ALPHANUM_SEG_B  0b0000000000000010  ///< Alphanumeric segment B
-#define ALPHANUM_SEG_C  0b0000000000000100  ///< Alphanumeric segment C
-#define ALPHANUM_SEG_D  0b0000000000001000  ///< Alphanumeric segment D
-#define ALPHANUM_SEG_E  0b0000000000010000  ///< Alphanumeric segment E
-#define ALPHANUM_SEG_F  0b0000000000100000  ///< Alphanumeric segment F
+#define ALPHANUM_SEG_A 0b0000000000000001  ///< Alphanumeric segment A
+#define ALPHANUM_SEG_B 0b0000000000000010  ///< Alphanumeric segment B
+#define ALPHANUM_SEG_C 0b0000000000000100  ///< Alphanumeric segment C
+#define ALPHANUM_SEG_D 0b0000000000001000  ///< Alphanumeric segment D
+#define ALPHANUM_SEG_E 0b0000000000010000  ///< Alphanumeric segment E
+#define ALPHANUM_SEG_F 0b0000000000100000  ///< Alphanumeric segment F
 #define ALPHANUM_SEG_G1 0b0000000001000000  ///< Alphanumeric segment G1
 #define ALPHANUM_SEG_G2 0b0000000010000000  ///< Alphanumeric segment G2
-#define ALPHANUM_SEG_H  0b0000000100000000  ///< Alphanumeric segment H
-#define ALPHANUM_SEG_J  0b0000001000000000  ///< Alphanumeric segment J
-#define ALPHANUM_SEG_K  0b0000010000000000  ///< Alphanumeric segment K
-#define ALPHANUM_SEG_L  0b0000100000000000  ///< Alphanumeric segment L
-#define ALPHANUM_SEG_M  0b0001000000000000  ///< Alphanumeric segment M
-#define ALPHANUM_SEG_N  0b0010000000000000  ///< Alphanumeric segment N
+#define ALPHANUM_SEG_H 0b0000000100000000  ///< Alphanumeric segment H
+#define ALPHANUM_SEG_J 0b0000001000000000  ///< Alphanumeric segment J
+#define ALPHANUM_SEG_K 0b0000010000000000  ///< Alphanumeric segment K
+#define ALPHANUM_SEG_L 0b0000100000000000  ///< Alphanumeric segment L
+#define ALPHANUM_SEG_M 0b0001000000000000  ///< Alphanumeric segment M
+#define ALPHANUM_SEG_N 0b0010000000000000  ///< Alphanumeric segment N
 #define ALPHANUM_SEG_DP 0b0100000000000000  ///< Alphanumeric segment DP
 
 /*!

--- a/Adafruit_LEDBackpack.h
+++ b/Adafruit_LEDBackpack.h
@@ -56,15 +56,15 @@
 #define ALPHANUM_SEG_D 0b0000000000001000  ///< Alphanumeric segment D
 #define ALPHANUM_SEG_E 0b0000000000010000  ///< Alphanumeric segment E
 #define ALPHANUM_SEG_F 0b0000000000100000  ///< Alphanumeric segment F
-#define ALPHANUM_SEG_G1 0b0000000001000000  ///< Alphanumeric segment G1
-#define ALPHANUM_SEG_G2 0b0000000010000000  ///< Alphanumeric segment G2
+#define ALPHANUM_SEG_G1 0b0000000001000000 ///< Alphanumeric segment G1
+#define ALPHANUM_SEG_G2 0b0000000010000000 ///< Alphanumeric segment G2
 #define ALPHANUM_SEG_H 0b0000000100000000  ///< Alphanumeric segment H
 #define ALPHANUM_SEG_J 0b0000001000000000  ///< Alphanumeric segment J
 #define ALPHANUM_SEG_K 0b0000010000000000  ///< Alphanumeric segment K
 #define ALPHANUM_SEG_L 0b0000100000000000  ///< Alphanumeric segment L
 #define ALPHANUM_SEG_M 0b0001000000000000  ///< Alphanumeric segment M
 #define ALPHANUM_SEG_N 0b0010000000000000  ///< Alphanumeric segment N
-#define ALPHANUM_SEG_DP 0b0100000000000000  ///< Alphanumeric segment DP
+#define ALPHANUM_SEG_DP 0b0100000000000000 ///< Alphanumeric segment DP
 
 /*!
     @brief  Class encapsulating the raw HT16K33 controller device.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Atmega328 @ 12MHz |      X       |             |            |
 Atmega32u4 @ 16MHz |      X       |             |            | 
 Atmega32u4 @ 8MHz |      X       |             |            | 
 ESP8266           |      X       |             |            | 
+ESP32             |      X       |             |            |
+ESP32S2           |      X       |             |            |
+ESP32S3           |      X       |             |            |
 Atmega2560 @ 16MHz |      X       |             |            | 
 ATSAM3X8E         |      X       |             |            | Use SDA/SCL on pins 20 &amp; 21
 ATSAM21D          |      X       |             |            | 
@@ -21,6 +24,9 @@ ATtiny85 @ 8MHz   |      X       |             |            | Use 0 for SDA, 2 f
   * ATmega32u4 @ 16MHz : Arduino Leonardo, Arduino Micro, Arduino Yun, Teensy 2.0
   * ATmega32u4 @ 8MHz : Adafruit Flora, Bluefruit Micro
   * ESP8266 : Adafruit Huzzah
+  * ESP32 : Unexpected Maker tinyPICO
+  * ESP32S2 : Unexpected Maker tinyS2
+  * ESP32S3 : Unexpected Maker tinyS3
   * ATmega2560 @ 16MHz : Arduino Mega
   * ATSAM3X8E : Arduino Due
   * ATSAM21D : Arduino Zero, M0 Pro

--- a/examples/quadalphaanimation/quadalphaanimation.ino
+++ b/examples/quadalphaanimation/quadalphaanimation.ino
@@ -1,0 +1,42 @@
+// This example shows how to use the alphanumeric segment names in an animation.
+//
+// Author: Jonny Bergdahl (github@bergdahl.org)
+//
+#include <Arduino.h>
+#include <Adafruit_LEDBackpack.h>
+
+Adafruit_AlphaNum4 alpha4 = Adafruit_AlphaNum4();
+// Defines the animation. For segment names, 
+// see https://learn.adafruit.com/14-segment-alpha-numeric-led-featherwing/usage
+uint16_t animation[] { 0, ALPHANUM_SEG_A, 
+                       1, ALPHANUM_SEG_H, 
+                       1, ALPHANUM_SEG_N, 
+                       2, ALPHANUM_SEG_L, 
+                       2, ALPHANUM_SEG_K, 
+                       3, ALPHANUM_SEG_A, 
+                       3, ALPHANUM_SEG_B, 
+                       3, ALPHANUM_SEG_C, 
+                       3, ALPHANUM_SEG_D, 
+                       2, ALPHANUM_SEG_N,
+                       2, ALPHANUM_SEG_H, 
+                       1, ALPHANUM_SEG_K,
+                       1, ALPHANUM_SEG_L, 
+                       0, ALPHANUM_SEG_D,
+                       0, ALPHANUM_SEG_E,
+                       0, ALPHANUM_SEG_F };
+
+void setup() {
+  Serial.begin(9600);  
+  alpha4.begin(0x70);  // pass in the address
+}
+
+void loop() {
+  // For each step of the animation, write the value to the given digit
+  for (int j = 0; j < sizeof(animation)/2; j = j + 2)
+  {
+    alpha4.clear();
+    alpha4.writeDigitRaw(animation[j], animation[j+1]);
+    alpha4.writeDisplay();
+    delay(200);
+  }
+}

--- a/examples/quadalphaanimation/quadalphaanimation.ino
+++ b/examples/quadalphaanimation/quadalphaanimation.ino
@@ -26,22 +26,22 @@ See https://learn.adafruit.com/14-segment-alpha-numeric-led-featherwing/usage
     -------D-------  DP
 */
 
-uint16_t animation[] { 0, ALPHANUM_SEG_A, 
-                       1, ALPHANUM_SEG_H, 
-                       1, ALPHANUM_SEG_N, 
-                       2, ALPHANUM_SEG_L, 
-                       2, ALPHANUM_SEG_K, 
-                       3, ALPHANUM_SEG_A, 
-                       3, ALPHANUM_SEG_B, 
-                       3, ALPHANUM_SEG_C, 
-                       3, ALPHANUM_SEG_D, 
-                       2, ALPHANUM_SEG_N,
-                       2, ALPHANUM_SEG_H, 
-                       1, ALPHANUM_SEG_K,
-                       1, ALPHANUM_SEG_L, 
-                       0, ALPHANUM_SEG_D,
-                       0, ALPHANUM_SEG_E,
-                       0, ALPHANUM_SEG_F };
+uint16_t animation[] { 0, ALPHANUM_SEG_A | ALPHANUM_SEG_D, 
+                       1, ALPHANUM_SEG_H | ALPHANUM_SEG_L, 
+                       1, ALPHANUM_SEG_N | ALPHANUM_SEG_K, 
+                       2, ALPHANUM_SEG_L | ALPHANUM_SEG_H, 
+                       2, ALPHANUM_SEG_K | ALPHANUM_SEG_N, 
+                       3, ALPHANUM_SEG_A | ALPHANUM_SEG_D, 
+                       3, ALPHANUM_SEG_B | ALPHANUM_SEG_C, 
+                       3, ALPHANUM_SEG_C | ALPHANUM_SEG_B, 
+                       3, ALPHANUM_SEG_D | ALPHANUM_SEG_A, 
+                       2, ALPHANUM_SEG_N | ALPHANUM_SEG_K,
+                       2, ALPHANUM_SEG_H | ALPHANUM_SEG_L, 
+                       1, ALPHANUM_SEG_K | ALPHANUM_SEG_N,
+                       1, ALPHANUM_SEG_L | ALPHANUM_SEG_H, 
+                       0, ALPHANUM_SEG_D | ALPHANUM_SEG_A,
+                       0, ALPHANUM_SEG_E | ALPHANUM_SEG_F,
+                       0, ALPHANUM_SEG_F | ALPHANUM_SEG_E };
 
 void setup() {
   Serial.begin(9600);  

--- a/examples/quadalphaanimation/quadalphaanimation.ino
+++ b/examples/quadalphaanimation/quadalphaanimation.ino
@@ -6,8 +6,26 @@
 #include <Adafruit_LEDBackpack.h>
 
 Adafruit_AlphaNum4 alpha4 = Adafruit_AlphaNum4();
-// Defines the animation. For segment names, 
-// see https://learn.adafruit.com/14-segment-alpha-numeric-led-featherwing/usage
+
+/*
+Segment names for 14-segment alphanumeric displays.
+See https://learn.adafruit.com/14-segment-alpha-numeric-led-featherwing/usage
+
+    -------A-------
+    |\     |     /|
+    | \    J    / |
+    |   H  |  K   |
+    F    \ | /    B
+    |     \|/     |
+    |--G1--|--G2--|
+    |     /|\     |
+    E    / | \    C
+    |   L  |   N  |
+    | /    M    \ |
+    |/     |     \|
+    -------D-------  DP
+*/
+
 uint16_t animation[] { 0, ALPHANUM_SEG_A, 
                        1, ALPHANUM_SEG_H, 
                        1, ALPHANUM_SEG_N, 


### PR DESCRIPTION
I added segment name defines to make it easier for the user to use the alphanumeric display. I also added a simple animation that shows how to use the defines.

It makes it possible to write code like this - `alpha4.writeDigitRaw(0, ALPHANUM_SEG_C);`, which is way more readanle than  `alpha4.writeDigitRaw(0, 0c0004);`.

